### PR TITLE
Bugfix/error-keyword

### DIFF
--- a/src/main/resources/static/error_keywords/errors_en.txt
+++ b/src/main/resources/static/error_keywords/errors_en.txt
@@ -1,3 +1,4 @@
+available
 be saved
 blocked
 booted me

--- a/src/main/resources/static/error_keywords/errors_fr.txt
+++ b/src/main/resources/static/error_keywords/errors_fr.txt
@@ -4,6 +4,7 @@ bouton d'envoi
 cassé
 chargement trop long
 décliné
+disponible
 défilement
 échec de la connexion sécurisée
 en construction

--- a/src/main/resources/templates/pageFeedback_en.html
+++ b/src/main/resources/templates/pageFeedback_en.html
@@ -160,7 +160,7 @@
                 <label>
                   <input type="checkbox" id="errorComments" name="errorComments">
                   Show feedback with <a
-                    href="https://github.com/alpha-canada-ca/feedback-viewer/error_keywords/src/main/resources/static/error_keywords"
+                    href="https://github.com/alpha-canada-ca/feedback-viewer/tree/master/src/main/resources/static/error_keywords"
                     target="_blank">error keywords</a>
                 </label>
               </p>

--- a/src/main/resources/templates/pageFeedback_fr.html
+++ b/src/main/resources/templates/pageFeedback_fr.html
@@ -160,7 +160,7 @@
                 <label>
                   <input type="checkbox" id="errorComments" name="errorComments">
                   Afficher les commentaires avec les <a
-                    href="https://github.com/alpha-canada-ca/feedback-viewer/error_keywords/src/main/resources/static/error_keywords"
+                    href="https://github.com/alpha-canada-ca/feedback-viewer/tree/master/src/main/resources/static/error_keywords"
                     target="_blank">mots-clés d'erreur</a>
                 </label>
               </p>


### PR DESCRIPTION
- Bug: the link to the error keyword list in the Feeback Viewer is currentlly 404. 
- Add “available” / “disponible” to the error keyword list.