### PR TITLE
Maintenance/error-keywords-list

### DIFF
--- a/src/main/resources/static/error_keywords/errors_bilingual.txt
+++ b/src/main/resources/static/error_keywords/errors_bilingual.txt
@@ -1,6 +1,5 @@
 403
 404
 chrome
-ERR.004
 firefox
 ERR.

--- a/src/main/resources/static/error_keywords/errors_bilingual.txt
+++ b/src/main/resources/static/error_keywords/errors_bilingual.txt
@@ -3,3 +3,4 @@
 chrome
 ERR.004
 firefox
+ERR.

--- a/src/main/resources/static/error_keywords/errors_en.txt
+++ b/src/main/resources/static/error_keywords/errors_en.txt
@@ -1,3 +1,4 @@
+access page
 available
 be saved
 blocked
@@ -9,11 +10,17 @@ bumped out
 button is disabled
 can not move forward
 can not submit
+can not open
+can't open
+couldn't select
+can't sign in
+cannot log in
 can't submit
 can't upload
 cannot submit
 cannot upload
 capatcha
+could not
 could not move on
 couldn’t be submitted
 couldn't submit
@@ -21,12 +28,17 @@ couldn't upload
 crash
 dead end
 declined
+did not match
+didn't show
+does not function
+doesn't function
 did not function
 did not work
 didn't work
 does not work
 doesn't connect
 doesn't work
+down again
 error
 error message
 err.
@@ -42,6 +54,11 @@ long loading
 loop
 maintenance
 never able to
+network issue
+never working
+not functioning
+not available
+not upload
 no success
 not compatible
 not letting me
@@ -50,6 +67,9 @@ not saving
 not worked
 not working
 nothing happened
+out of service
+page does not exist
+page doesn't exist
 page not found
 proxy
 re-direct
@@ -60,7 +80,10 @@ scrolling
 secure connection failed
 server
 Service not available
+service unavailable
 site has been down
+site is down
+something went wrong
 something was wrong
 stuck
 submit button
@@ -68,6 +91,9 @@ system down
 system says
 system wasn't available
 system won't
+technical problem
+temporary down
+to no avail
 time out
 time to load
 timed out
@@ -76,6 +102,9 @@ timeout
 timing out
 typo
 unable to advance
+unable to get
+unable to submit
+unable to update
 unavailable
 under construction
 under maintenance
@@ -84,6 +113,7 @@ was down
 wasn't available
 website is down
 website problem
+website is down
 website was down
 why can't I
 why cant I
@@ -97,12 +127,9 @@ would not accept
 wouldn't accept
 wouldn't complete
 wouldn't load
+wrong
 you don't accept
 your system
-can't sign in
-cannot log in
-down again
-not available
-not upload
-service unavailable
-website is down
+
+
+

--- a/src/main/resources/static/error_keywords/errors_en.txt
+++ b/src/main/resources/static/error_keywords/errors_en.txt
@@ -29,6 +29,7 @@ doesn't connect
 doesn't work
 error
 error message
+err.
 froze
 getting a fault
 glitch

--- a/src/main/resources/static/error_keywords/errors_en.txt
+++ b/src/main/resources/static/error_keywords/errors_en.txt
@@ -17,6 +17,10 @@ can't sign in
 cannot log in
 can't submit
 can't upload
+can not get past
+can't get past
+cannot load
+could not access
 cannot submit
 cannot upload
 capatcha
@@ -43,6 +47,8 @@ error
 error message
 err.
 froze
+freezes
+frozen
 getting a fault
 glitch
 greyed out

--- a/src/main/resources/static/error_keywords/errors_fr.txt
+++ b/src/main/resources/static/error_keywords/errors_fr.txt
@@ -16,7 +16,15 @@ err.
 fonctionne pas
 gelé
 grisé
+hors service
 impasse
+impossible d'envoyer
+impossible d'obtenir
+impossible d'ouvrir
+impossible de mettre à jour
+impossible de sélectionner
+incorrect
+indisponible temporairement
 indisponible
 le bouton est désactivé
 m'a bloqué
@@ -29,6 +37,8 @@ n'achèvera pas
 navigateur
 ne chargera pas
 ne me laisse pas faire
+ne fonctionne jamais
+ne fonctionne pas
 ne pas me laisser
 ne pas sauver
 ne peut être soumis
@@ -40,8 +50,12 @@ ne peut pas télécharger
 ne se charge pas
 ne se connecte pas
 ne se soumet pas
+ne s'affiche pas
 ne travaillera pas
 page non trouvée
+page inexistante
+problème réseau
+problème technique
 pas compatible
 pas de sauvegarde
 pas de succès
@@ -61,6 +75,7 @@ rien ne s'est passé
 sans réponse
 serveur
 Service non disponible
+site indisponible
 télécharger
 temps d'attente
 temps de chargement

--- a/src/main/resources/static/error_keywords/errors_fr.txt
+++ b/src/main/resources/static/error_keywords/errors_fr.txt
@@ -11,6 +11,7 @@ en construction
 en maintenance
 en panne
 erreur
+err.
 être sauvegardé
 fonctionne pas
 gelé


### PR DESCRIPTION
Added err. to English/French text documents and ERR. in the bilingual document to cover more error keywords.
Also added these keywords from google doc from Oct 20th: 
https://docs.google.com/spreadsheets/d/1NzqIhr0NOFNB5B8f1cSdbQe-93uILeSDWZXr1Y2rNM4/edit?gid=0#gid=0