### PR TITLE
Feat/default-comment-count

### DIFF
--- a/src/main/resources/static/js/pageFeedback-dashboard.js
+++ b/src/main/resources/static/js/pageFeedback-dashboard.js
@@ -118,6 +118,7 @@ $(document).ready(function () {
       [10, 25, 50, 100],
       [10, 25, 50, 100],
     ],
+    pageLength: 50,
     orderCellsTop: true,
     fixedHeader: true,
     responsive: true,

--- a/src/main/resources/static/js/pageFeedback.js
+++ b/src/main/resources/static/js/pageFeedback.js
@@ -149,6 +149,7 @@ $(document).ready(function () {
       [10, 25, 50, 100],
       [10, 25, 50, 100],
     ],
+    pageLength: 50, //adds default comment count to 50
     orderCellsTop: true,
     fixedHeader: true,
     responsive: true,


### PR DESCRIPTION
Adds default page length entries in the data table to 50 instead of 10