### PR TITLE
bugfix/dashboard-date-error

### DIFF
--- a/src/main/java/ca/gc/tbs/controller/DashboardController.java
+++ b/src/main/java/ca/gc/tbs/controller/DashboardController.java
@@ -620,6 +620,7 @@ public class DashboardController {
             // Filter out future dates
             LocalDate currentDate = LocalDate.now();
             mergedProblems = mergedProblems.stream()
+                .filter(p -> isValidDate(p.getProblemDate(), DateTimeFormatter.ISO_LOCAL_DATE))
                 .filter(p -> {
                     LocalDate problemDate = LocalDate.parse(p.getProblemDate(), DateTimeFormatter.ISO_LOCAL_DATE);
                     return !problemDate.isAfter(currentDate);
@@ -824,10 +825,9 @@ public class DashboardController {
                                     .values());
 
             LocalDate currentDate = LocalDate.now();
-            problems =
-                    problems.stream()
-                            .filter(
-                                    p -> {
+            problems = problems.stream()
+                            .filter(p -> isValidDate(p.getProblemDate(), DateTimeFormatter.ISO_LOCAL_DATE))
+                            .filter(p -> {
                                         LocalDate problemDate =
                                                 LocalDate.parse(p.getProblemDate(), DateTimeFormatter.ISO_LOCAL_DATE);
                                         return !problemDate.isAfter(currentDate); //was isBefore - changed to !isAfter for more entries including current date
@@ -870,6 +870,16 @@ public class DashboardController {
 
         return output;
     }
+
+    private static boolean isValidDate(String value, DateTimeFormatter formatter) {
+        try {
+            LocalDate.parse(value, formatter);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
     //Helper method for criteria building with filters
     private Criteria buildFilterCriteria(String startDate, String endDate, String theme,
                                          String section, String language, String url,
@@ -984,6 +994,7 @@ public class DashboardController {
             LocalDate end = LocalDate.parse(endDate, formatter);
 
             return problems.stream()
+                    .filter(problem -> isValidDate(problem.getProblemDate(), formatter))
                     .filter(
                             problem -> {
                                 LocalDate problemDate = LocalDate.parse(problem.getProblemDate(), formatter);


### PR DESCRIPTION
This error at line 624 and 832:
Text '14:12' could not be parsed at index 0
	at java.time.format.DateTimeFormatter.parseResolved0(DateTimeFormatter.java:1949) ~[na:1.8.0_462]
	at java.time.format.DateTimeFormatter.parse(DateTimeFormatter.java:1851) ~[na:1.8.0_462]
	
The dashboard was getting data that shows time 14:12 instead of the date which was causing an error for LocalDate.parse.