### PR TITLE
fix: use applyDepartmentFilter in buildExportCriteria for TSS download

### DIFF
--- a/src/main/java/ca/gc/tbs/controller/TopTaskController.java
+++ b/src/main/java/ca/gc/tbs/controller/TopTaskController.java
@@ -878,7 +878,8 @@ public class TopTaskController {
       criteria.and("grouping").is(group);
     }
     if (department != null && !department.isEmpty()) {
-      criteria.and("dept").regex("^" + Pattern.quote(department) + "$", "i");
+      Criteria departmentCriteria = applyDepartmentFilter(new Criteria(), department);
+      criteria = new Criteria().andOperator(criteria, departmentCriteria);
     }
 
     List<Criteria> combinedOrCriteria = new ArrayList<>();


### PR DESCRIPTION
Department filter was applying a raw regex match in buildExportCriteria, bypassing institutionMappings. Departments like HICC (mapped under INFC) returned no results on export while appearing correctly in the table view. Now uses applyDepartmentFilter() consistently across both table and export.