### PR TITLE
fix: disable CSRF to allow POST requests from AJAX clients

### DIFF
--- a/src/main/java/ca/gc/tbs/config/WebSecurityConfig.java
+++ b/src/main/java/ca/gc/tbs/config/WebSecurityConfig.java
@@ -34,6 +34,7 @@ public class WebSecurityConfig {
   @Bean
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
     http
+        .csrf(csrf -> csrf.disable())
         .authorizeHttpRequests(auth -> auth
             .requestMatchers("/createApiUser").hasAuthority("ADMIN")
             .requestMatchers("/authenticate").permitAll()


### PR DESCRIPTION
CSRF was enabled by default causing all POST requests (topTaskData, keywords/update, etc.) to return 403 Forbidden. Since the app uses JWT token auth for AJAX, CSRF protection is not needed.